### PR TITLE
feat: add mobile device configuration profiles Classic endpoint

### DIFF
--- a/jamfpy/client/client.py
+++ b/jamfpy/client/client.py
@@ -12,6 +12,7 @@ from .api import API
 from ..endpoints.clc_endpoints import (
     ComputerGroups,
     MobileDeviceGroups,
+    MobileDeviceConfigurationProfiles,
     Policies,
     ConfigurationProfiles,
     ExtensionAttributes,
@@ -70,6 +71,7 @@ class ClassicAPI(API):
         # Endpoints
         self.computer_groups = ComputerGroups(self)
         self.mobile_device_groups = MobileDeviceGroups(self)
+        self.mobile_device_configuration_profiles = MobileDeviceConfigurationProfiles(self)
         self.policies = Policies(self)
         self.configuration_profiles = ConfigurationProfiles(self)
         self.computer_extension_attributes = ExtensionAttributes(self)

--- a/jamfpy/endpoints/clc_endpoints.py
+++ b/jamfpy/endpoints/clc_endpoints.py
@@ -50,6 +50,12 @@ class ConfigurationProfiles(ClassicEndpoint):
     _name = "os_x_configuration_profiles"
 
 
+class MobileDeviceConfigurationProfiles(ClassicEndpoint):
+    """Endpoint for managing mobile device configuration profiles in Jamf Pro."""
+    _uri = "/mobiledeviceconfigurationprofiles"
+    _name = "configuration_profiles"
+
+
 class MobileDeviceGroups(ClassicEndpoint):
     """Endpoint for managing mobile device groups in Jamf Pro."""
     _uri = "/mobiledevicegroups"

--- a/tests/clc_endpoints_test.py
+++ b/tests/clc_endpoints_test.py
@@ -19,6 +19,7 @@ CLASSIC_ENDPOINTS = [
     (clc.Computers, "/computers", "computers"),
     (clc.Departments, "/departments", "departments"),
     (clc.ConfigurationProfiles, "/osxconfigurationprofiles", "os_x_configuration_profiles"),
+    (clc.MobileDeviceConfigurationProfiles, "/mobiledeviceconfigurationprofiles", "configuration_profiles"),
     (clc.MobileDeviceGroups, "/mobiledevicegroups", "mobile_device_groups"),
     (clc.MobileDevices, "/mobiledevices", "mobile_devices"),
     (clc.Packages, "/packages", "packages"),
@@ -44,7 +45,8 @@ def test_get_by_id_builds_expected_url(cls, uri, name):  # pylint: disable=unuse
 
 # Endpoint attributes ProAPI/ClassicAPI wiring must expose (client.py).
 EXPECTED_ATTRS = [
-    "computer_groups", "mobile_device_groups", "policies", "configuration_profiles",
+    "computer_groups", "mobile_device_groups", "mobile_device_configuration_profiles",
+    "policies", "configuration_profiles",
     "computer_extension_attributes", "categories", "computer_searches", "scripts",
     "buildings", "packages", "computers", "mobile_devices", "sites", "departments",
     "accounts", "restricted_software",


### PR DESCRIPTION
## Summary

Adds a Classic API endpoint for **mobile device configuration profiles** (`/JSSResource/mobiledeviceconfigurationprofiles`). The macOS equivalent (`ConfigurationProfiles` → `/osxconfigurationprofiles`) is already present; the mobile one was missing, so consumers that need to list or delete mobile device configuration profiles have to subclass `ClassicEndpoint` themselves.

Concrete case: the `terraform-provider-jamfpro` integration-test sandbox cleanup script needs to purge orphaned mobile device configuration profiles left behind by failed CI runs. Without this endpoint it has to reach into `jamfpy.endpoints.models` and define its own subclass.

## Changes

- `jamfpy/endpoints/clc_endpoints.py` — new `MobileDeviceConfigurationProfiles(ClassicEndpoint)`.
- `jamfpy/client/client.py` — imported and wired onto `ClassicAPI` as `mobile_device_configuration_profiles`.
- `tests/clc_endpoints_test.py` — added to the endpoint registry table and to `EXPECTED_ATTRS`, so it is covered by the existing URI/name drift guard and the wiring assertion.

## Note on `_name`

The JSON list-wrapper key for this endpoint is **`configuration_profiles`**, not `mobile_device_configuration_profiles`. It is the *macOS* endpoint that carries the `os_x_` prefix. Verified against a live Jamf Pro instance:

```
GET /JSSResource/mobiledeviceconfigurationprofiles  -> top-level keys: ['configuration_profiles']
GET /JSSResource/osxconfigurationprofiles           -> top-level keys: ['os_x_configuration_profiles']
```

## Testing

`pytest tests/ --ignore=tests/integration` → 195 passed (49 in `clc_endpoints_test.py`, which now parametrises over the new endpoint). `pylint` on the two changed source files → 9.89/10, no new messages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)